### PR TITLE
feat: Add footer component with copyright and GitHub link

### DIFF
--- a/src/app/app.css
+++ b/src/app/app.css
@@ -1,12 +1,18 @@
+:host {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+}
+
 .hello-world-container {
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  min-height: 100vh;
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  flex: 1;
   text-align: center;
-  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
   color: white;
   margin: 0;
   padding: 20px;

--- a/src/app/app.html
+++ b/src/app/app.html
@@ -4,3 +4,5 @@
 </main>
 
 <router-outlet />
+
+<app-footer />

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -1,9 +1,10 @@
 import { Component } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
+import { FooterComponent } from './footer/footer';
 
 @Component({
   selector: 'app-root',
-  imports: [RouterOutlet],
+  imports: [RouterOutlet, FooterComponent],
   templateUrl: './app.html',
   styleUrl: './app.css'
 })

--- a/src/app/footer/footer.css
+++ b/src/app/footer/footer.css
@@ -1,0 +1,29 @@
+.app-footer {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+  background-color: rgba(0, 0, 0, 0.2);
+  color: white;
+  text-align: center;
+  gap: 8px;
+}
+
+.app-footer p {
+  margin: 0;
+  font-size: 0.9rem;
+  opacity: 0.9;
+}
+
+.app-footer a {
+  color: white;
+  text-decoration: underline;
+  font-size: 0.9rem;
+  opacity: 0.8;
+  transition: opacity 0.2s ease;
+}
+
+.app-footer a:hover {
+  opacity: 1;
+}

--- a/src/app/footer/footer.html
+++ b/src/app/footer/footer.html
@@ -1,0 +1,4 @@
+<footer class="app-footer">
+  <p>&copy; {{ currentYear }} {{ appName }}</p>
+  <a [href]="githubUrl" target="_blank" rel="noopener noreferrer">GitHub Repository</a>
+</footer>

--- a/src/app/footer/footer.spec.ts
+++ b/src/app/footer/footer.spec.ts
@@ -1,0 +1,45 @@
+import { TestBed } from '@angular/core/testing';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { FooterComponent } from './footer';
+
+describe('FooterComponent', () => {
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [FooterComponent]
+    }).compileComponents();
+  });
+
+  it('should create', () => {
+    const fixture = TestBed.createComponent(FooterComponent);
+    const component = fixture.componentInstance;
+    expect(component).toBeTruthy();
+  });
+
+  it('should display copyright year 2026', async () => {
+    const fixture = TestBed.createComponent(FooterComponent);
+    const component = fixture.componentInstance;
+    expect(component.currentYear).toBe(2026);
+    await fixture.whenStable();
+    const compiled = fixture.nativeElement as HTMLElement;
+    expect(compiled.textContent).toContain('2026');
+  });
+
+  it('should display app name Simple Dashboard', async () => {
+    const fixture = TestBed.createComponent(FooterComponent);
+    const component = fixture.componentInstance;
+    expect(component.appName).toBe('Simple Dashboard');
+    await fixture.whenStable();
+    const compiled = fixture.nativeElement as HTMLElement;
+    expect(compiled.textContent).toContain('Simple Dashboard');
+  });
+
+  it('should have a link to GitHub repository', async () => {
+    const fixture = TestBed.createComponent(FooterComponent);
+    await fixture.whenStable();
+    const compiled = fixture.nativeElement as HTMLElement;
+    const link = compiled.querySelector('a');
+    expect(link).toBeTruthy();
+    expect(link?.href).toBe('https://github.com/vinay4appsentinels/simple-dashboard');
+    expect(link?.target).toBe('_blank');
+  });
+});

--- a/src/app/footer/footer.ts
+++ b/src/app/footer/footer.ts
@@ -1,0 +1,13 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-footer',
+  standalone: true,
+  templateUrl: './footer.html',
+  styleUrl: './footer.css'
+})
+export class FooterComponent {
+  currentYear = 2026;
+  appName = 'Simple Dashboard';
+  githubUrl = 'https://github.com/vinay4appsentinels/simple-dashboard';
+}


### PR DESCRIPTION
## Summary
- Created a reusable `FooterComponent` that displays copyright 2026, app name "Simple Dashboard", and a link to the GitHub repository
- Integrated footer at the bottom of the main app component using flexbox layout
- Added comprehensive unit tests for the footer component (4 tests)

## Changes
- `src/app/footer/footer.ts` - Footer component class
- `src/app/footer/footer.html` - Footer template
- `src/app/footer/footer.css` - Footer styles
- `src/app/footer/footer.spec.ts` - Unit tests
- `src/app/app.ts` - Import and register footer component
- `src/app/app.html` - Add footer selector
- `src/app/app.css` - Update layout for proper footer positioning

## Test plan
- [x] Build passes: `npm run build`
- [x] All tests pass: `npm test` (7 tests, including 4 new footer tests)
- [x] Footer displays copyright year 2026
- [x] Footer displays app name "Simple Dashboard"
- [x] Footer contains GitHub repository link with target="_blank"
- [x] Footer positioned at the bottom of the page

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)