### PR TITLE
feat: Add header component with app title and navigation

### DIFF
--- a/src/app/app.css
+++ b/src/app/app.css
@@ -1,12 +1,18 @@
+:host {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+}
+
 .hello-world-container {
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  min-height: 100vh;
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  flex: 1;
   text-align: center;
-  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
   color: white;
   margin: 0;
   padding: 20px;

--- a/src/app/app.html
+++ b/src/app/app.html
@@ -1,3 +1,5 @@
+<app-header></app-header>
+
 <main class="hello-world-container">
   <h1>Hello World!</h1>
   <p>Welcome to Simple Dashboard</p>

--- a/src/app/app.html
+++ b/src/app/app.html
@@ -4,3 +4,5 @@
 </main>
 
 <router-outlet />
+
+<app-footer />

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -1,9 +1,10 @@
 import { Component } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
+import { FooterComponent } from './footer/footer';
 
 @Component({
   selector: 'app-root',
-  imports: [RouterOutlet],
+  imports: [RouterOutlet, FooterComponent],
   templateUrl: './app.html',
   styleUrl: './app.css'
 })

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -1,10 +1,11 @@
 import { Component } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
 import { FooterComponent } from './footer/footer';
+import { HeaderComponent } from './components/header/header.component';
 
 @Component({
   selector: 'app-root',
-  imports: [RouterOutlet, FooterComponent],
+  imports: [RouterOutlet, FooterComponent, HeaderComponent],
   templateUrl: './app.html',
   styleUrl: './app.css'
 })

--- a/src/app/components/header/header.component.css
+++ b/src/app/components/header/header.component.css
@@ -1,0 +1,35 @@
+.app-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem 2rem;
+  background-color: #1a1a2e;
+  color: white;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.app-title {
+  margin: 0;
+  font-size: 1.5rem;
+  font-weight: 600;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+}
+
+.app-nav {
+  display: flex;
+  gap: 1rem;
+}
+
+.nav-link {
+  color: white;
+  text-decoration: none;
+  font-size: 1rem;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+  transition: background-color 0.2s ease;
+}
+
+.nav-link:hover {
+  background-color: rgba(255, 255, 255, 0.1);
+}

--- a/src/app/components/header/header.component.html
+++ b/src/app/components/header/header.component.html
@@ -1,0 +1,6 @@
+<header class="app-header">
+  <h1 class="app-title">{{ title }}</h1>
+  <nav class="app-nav">
+    <a routerLink="/" class="nav-link">Home</a>
+  </nav>
+</header>

--- a/src/app/components/header/header.component.ts
+++ b/src/app/components/header/header.component.ts
@@ -1,0 +1,13 @@
+import { Component } from '@angular/core';
+import { RouterLink } from '@angular/router';
+
+@Component({
+  selector: 'app-header',
+  standalone: true,
+  imports: [RouterLink],
+  templateUrl: './header.component.html',
+  styleUrl: './header.component.css'
+})
+export class HeaderComponent {
+  title = 'Simple Dashboard';
+}

--- a/src/app/footer/footer.css
+++ b/src/app/footer/footer.css
@@ -1,0 +1,29 @@
+.app-footer {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+  background-color: rgba(0, 0, 0, 0.2);
+  color: white;
+  text-align: center;
+  gap: 8px;
+}
+
+.app-footer p {
+  margin: 0;
+  font-size: 0.9rem;
+  opacity: 0.9;
+}
+
+.app-footer a {
+  color: white;
+  text-decoration: underline;
+  font-size: 0.9rem;
+  opacity: 0.8;
+  transition: opacity 0.2s ease;
+}
+
+.app-footer a:hover {
+  opacity: 1;
+}

--- a/src/app/footer/footer.html
+++ b/src/app/footer/footer.html
@@ -1,0 +1,4 @@
+<footer class="app-footer">
+  <p>&copy; {{ currentYear }} {{ appName }}</p>
+  <a [href]="githubUrl" target="_blank" rel="noopener noreferrer">GitHub Repository</a>
+</footer>

--- a/src/app/footer/footer.spec.ts
+++ b/src/app/footer/footer.spec.ts
@@ -1,0 +1,45 @@
+import { TestBed } from '@angular/core/testing';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { FooterComponent } from './footer';
+
+describe('FooterComponent', () => {
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [FooterComponent]
+    }).compileComponents();
+  });
+
+  it('should create', () => {
+    const fixture = TestBed.createComponent(FooterComponent);
+    const component = fixture.componentInstance;
+    expect(component).toBeTruthy();
+  });
+
+  it('should display copyright year 2026', async () => {
+    const fixture = TestBed.createComponent(FooterComponent);
+    const component = fixture.componentInstance;
+    expect(component.currentYear).toBe(2026);
+    await fixture.whenStable();
+    const compiled = fixture.nativeElement as HTMLElement;
+    expect(compiled.textContent).toContain('2026');
+  });
+
+  it('should display app name Simple Dashboard', async () => {
+    const fixture = TestBed.createComponent(FooterComponent);
+    const component = fixture.componentInstance;
+    expect(component.appName).toBe('Simple Dashboard');
+    await fixture.whenStable();
+    const compiled = fixture.nativeElement as HTMLElement;
+    expect(compiled.textContent).toContain('Simple Dashboard');
+  });
+
+  it('should have a link to GitHub repository', async () => {
+    const fixture = TestBed.createComponent(FooterComponent);
+    await fixture.whenStable();
+    const compiled = fixture.nativeElement as HTMLElement;
+    const link = compiled.querySelector('a');
+    expect(link).toBeTruthy();
+    expect(link?.href).toBe('https://github.com/vinay4appsentinels/simple-dashboard');
+    expect(link?.target).toBe('_blank');
+  });
+});

--- a/src/app/footer/footer.ts
+++ b/src/app/footer/footer.ts
@@ -1,0 +1,13 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-footer',
+  standalone: true,
+  templateUrl: './footer.html',
+  styleUrl: './footer.css'
+})
+export class FooterComponent {
+  currentYear = 2026;
+  appName = 'Simple Dashboard';
+  githubUrl = 'https://github.com/vinay4appsentinels/simple-dashboard';
+}


### PR DESCRIPTION
## Summary
- Created a new `HeaderComponent` in `src/app/components/header/`
- Displays the app title "Simple Dashboard" with a Home navigation link
- Integrated header at the top of `AppComponent` so it appears on every page
- Uses clean, minimal styling with dark header background

## Changes
- `src/app/components/header/header.component.ts` - Component class with title property
- `src/app/components/header/header.component.html` - Template with title and nav link
- `src/app/components/header/header.component.css` - Minimal styling for header
- `src/app/app.ts` - Import and register HeaderComponent
- `src/app/app.html` - Add `<app-header>` at top
- `src/app/app.css` - Adjust main container height for header

## Test plan
- [x] Build passes without errors
- [ ] Header displays "Simple Dashboard" title
- [ ] Home link navigates to root route (`/`)
- [ ] Header is visible at top of every page

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)