### PR TITLE
docs: Add snapshot guide for application screenshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,10 @@ ng e2e
 
 Angular CLI does not come with an end-to-end testing framework by default. You can choose one that suits your needs.
 
+## Documentation
+
+- [Snapshot Guide](docs/SNAPSHOT_GUIDE.md) - How to capture screenshots of the application using headless browser automation
+
 ## Additional Resources
 
 For more information on using the Angular CLI, including detailed command references, visit the [Angular CLI Overview and Command Reference](https://angular.dev/tools/cli) page.

--- a/docs/SNAPSHOT_GUIDE.md
+++ b/docs/SNAPSHOT_GUIDE.md
@@ -1,0 +1,278 @@
+# How to Take a Snapshot of the Application
+
+This guide documents the exact steps to clone the main branch, run the application, and capture a snapshot. Use this as a reference guide for future snapshot tasks.
+
+> **Note:** This process runs in a containerized environment without a display or headful browser. All screenshots must be captured using headless browser automation.
+
+## Table of Contents
+- [Prerequisites](#prerequisites)
+- [Step-by-Step Instructions](#step-by-step-instructions)
+- [Checklist](#checklist)
+- [Troubleshooting](#troubleshooting)
+- [Notes](#notes)
+
+## Prerequisites
+
+Before taking a snapshot, ensure you have the following installed:
+
+- **Node.js** (v18+ recommended)
+- **Angular CLI** installed globally (`npm install -g @angular/cli`)
+- **Git** installed
+- **Playwright or Puppeteer** installed for headless screenshot capture
+- **AWS CLI** configured for S3 uploads (if uploading to S3)
+
+## Step-by-Step Instructions
+
+### 1. Clone the Repository
+
+```bash
+git clone https://github.com/vinay4appsentinels/simple-dashboard.git
+cd simple-dashboard
+```
+
+### 2. Checkout Main Branch
+
+If not already on main:
+
+```bash
+git checkout main
+git pull origin main
+```
+
+### 3. Install Dependencies
+
+```bash
+npm install
+```
+
+### 4. Install Playwright
+
+If not already installed:
+
+```bash
+npm install -D playwright
+npx playwright install chromium
+```
+
+### 5. Run the Application in Background
+
+```bash
+ng serve &
+```
+
+Wait for the message:
+```
+** Angular Live Development Server is listening on localhost:4200 **
+```
+
+You can verify the server is running with:
+```bash
+curl -s http://localhost:4200 | head -20
+```
+
+### 6. Capture Screenshot Using Playwright (Headless)
+
+Create a script named `screenshot.js`:
+
+```javascript
+const { chromium } = require('playwright');
+
+(async () => {
+  const browser = await chromium.launch({ headless: true });
+  const page = await browser.newPage();
+
+  // Set viewport size for consistent screenshots
+  await page.setViewportSize({ width: 1280, height: 720 });
+
+  await page.goto('http://localhost:4200');
+  await page.waitForLoadState('networkidle');
+
+  // Wait a bit for any animations to complete
+  await page.waitForTimeout(1000);
+
+  await page.screenshot({ path: 'screenshot.png', fullPage: true });
+  await browser.close();
+
+  console.log('Screenshot saved: screenshot.png');
+})();
+```
+
+Run the script:
+
+```bash
+node screenshot.js
+```
+
+### 7. Upload to S3 (Optional)
+
+Upload the screenshot to S3 with a timestamp:
+
+```bash
+TIMESTAMP=$(date +%Y%m%d-%H%M%S)
+aws s3 cp screenshot.png s3://agent-screenshots-488922454646/vinay4appsentinels/simple-dashboard/snapshots/screenshot-${TIMESTAMP}.png --region us-east-1
+```
+
+Generate a pre-signed URL (valid for 7 days):
+
+```bash
+aws s3 presign s3://agent-screenshots-488922454646/vinay4appsentinels/simple-dashboard/snapshots/screenshot-${TIMESTAMP}.png --region us-east-1 --expires-in 604800
+```
+
+### 8. Attach to Relevant Issue
+
+Add the S3 URL as a comment to the relevant GitHub issue:
+
+```bash
+gh issue comment <issue-number> --repo vinay4appsentinels/simple-dashboard --body "Screenshot: <S3-URL>"
+```
+
+### 9. Cleanup
+
+Stop the background Angular server:
+
+```bash
+pkill -f "ng serve"
+```
+
+Or find and kill the specific process:
+
+```bash
+lsof -ti:4200 | xargs kill -9
+```
+
+## Checklist
+
+Use this checklist to ensure all steps are completed:
+
+- [ ] Repository cloned
+- [ ] Main branch checked out and up to date
+- [ ] Dependencies installed (`npm install`)
+- [ ] Playwright installed with Chromium
+- [ ] Application running on localhost:4200
+- [ ] Headless screenshot captured
+- [ ] Screenshot uploaded to S3 (if required)
+- [ ] S3 link attached to the relevant issue (if required)
+- [ ] Background server process stopped
+
+## Troubleshooting
+
+### Application fails to start
+
+**Error:** `ng: command not found`
+**Solution:** Install Angular CLI globally:
+```bash
+npm install -g @angular/cli
+```
+
+### Playwright browser installation fails
+
+**Error:** Missing system dependencies for Chromium
+**Solution:** Install system dependencies:
+```bash
+# On Ubuntu/Debian
+sudo apt-get install -y libnss3 libatk1.0-0 libatk-bridge2.0-0 libcups2 libxkbcommon0 libxcomposite1 libxdamage1 libxfixes3 libxrandr2 libgbm1 libpango-1.0-0 libcairo2 libasound2
+```
+
+Or use Playwright's built-in dependency installer:
+```bash
+npx playwright install-deps chromium
+```
+
+### Screenshot is blank or incomplete
+
+**Possible causes:**
+1. Application not fully loaded
+2. Network requests still pending
+
+**Solutions:**
+- Increase the `waitForTimeout` value
+- Use `waitForLoadState('networkidle')` to wait for all network requests
+- Add explicit waits for specific elements:
+```javascript
+await page.waitForSelector('app-root');
+```
+
+### Port 4200 already in use
+
+**Solution:** Kill the existing process:
+```bash
+lsof -ti:4200 | xargs kill -9
+```
+
+Or use a different port:
+```bash
+ng serve --port 4201 &
+```
+
+## Notes
+
+- **Always pull the latest main** before taking a snapshot to ensure you're capturing the current state
+- **Use headless browser** (Playwright/Puppeteer) - no display is available in containerized environments
+- **Consistent naming convention** - Use timestamps in filenames for traceability
+- **Resource cleanup** - Always stop the background `ng serve` process after capturing to free up resources
+- **Viewport consistency** - Set a standard viewport size (e.g., 1280x720) for consistent screenshots across captures
+
+## Quick Reference Script
+
+Here's a complete script that automates the entire snapshot process:
+
+```bash
+#!/bin/bash
+# snapshot.sh - Automated snapshot capture script
+
+set -e
+
+echo "Starting snapshot process..."
+
+# Ensure we're on main and up to date
+git checkout main
+git pull origin main
+
+# Install dependencies
+npm install
+
+# Install Playwright if needed
+npm install -D playwright
+npx playwright install chromium
+
+# Start the server in background
+ng serve &
+SERVER_PID=$!
+
+# Wait for server to be ready
+echo "Waiting for server to start..."
+while ! curl -s http://localhost:4200 > /dev/null; do
+  sleep 2
+done
+echo "Server is ready!"
+
+# Create screenshot script
+cat > /tmp/screenshot.js << 'EOF'
+const { chromium } = require('playwright');
+(async () => {
+  const browser = await chromium.launch({ headless: true });
+  const page = await browser.newPage();
+  await page.setViewportSize({ width: 1280, height: 720 });
+  await page.goto('http://localhost:4200');
+  await page.waitForLoadState('networkidle');
+  await page.waitForTimeout(1000);
+  await page.screenshot({ path: 'screenshot.png', fullPage: true });
+  await browser.close();
+  console.log('Screenshot saved: screenshot.png');
+})();
+EOF
+
+# Capture screenshot
+node /tmp/screenshot.js
+
+# Stop the server
+kill $SERVER_PID 2>/dev/null || true
+
+echo "Snapshot complete! Screenshot saved to screenshot.png"
+```
+
+Make the script executable:
+```bash
+chmod +x snapshot.sh
+./snapshot.sh
+```

--- a/src/app/app.css
+++ b/src/app/app.css
@@ -1,12 +1,18 @@
+:host {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+}
+
 .hello-world-container {
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  min-height: 100vh;
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  flex: 1;
   text-align: center;
-  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
   color: white;
   margin: 0;
   padding: 20px;

--- a/src/app/app.html
+++ b/src/app/app.html
@@ -1,3 +1,5 @@
+<app-header></app-header>
+
 <main class="hello-world-container">
   <h1>Hello World!</h1>
   <p>Welcome to Simple Dashboard</p>

--- a/src/app/app.html
+++ b/src/app/app.html
@@ -4,3 +4,5 @@
 </main>
 
 <router-outlet />
+
+<app-footer />

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -1,9 +1,10 @@
 import { Component } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
+import { FooterComponent } from './footer/footer';
 
 @Component({
   selector: 'app-root',
-  imports: [RouterOutlet],
+  imports: [RouterOutlet, FooterComponent],
   templateUrl: './app.html',
   styleUrl: './app.css'
 })

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -1,10 +1,11 @@
 import { Component } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
 import { FooterComponent } from './footer/footer';
+import { HeaderComponent } from './components/header/header.component';
 
 @Component({
   selector: 'app-root',
-  imports: [RouterOutlet, FooterComponent],
+  imports: [RouterOutlet, FooterComponent, HeaderComponent],
   templateUrl: './app.html',
   styleUrl: './app.css'
 })

--- a/src/app/components/header/header.component.css
+++ b/src/app/components/header/header.component.css
@@ -1,0 +1,35 @@
+.app-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem 2rem;
+  background-color: #1a1a2e;
+  color: white;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.app-title {
+  margin: 0;
+  font-size: 1.5rem;
+  font-weight: 600;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+}
+
+.app-nav {
+  display: flex;
+  gap: 1rem;
+}
+
+.nav-link {
+  color: white;
+  text-decoration: none;
+  font-size: 1rem;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+  transition: background-color 0.2s ease;
+}
+
+.nav-link:hover {
+  background-color: rgba(255, 255, 255, 0.1);
+}

--- a/src/app/components/header/header.component.html
+++ b/src/app/components/header/header.component.html
@@ -1,0 +1,6 @@
+<header class="app-header">
+  <h1 class="app-title">{{ title }}</h1>
+  <nav class="app-nav">
+    <a routerLink="/" class="nav-link">Home</a>
+  </nav>
+</header>

--- a/src/app/components/header/header.component.ts
+++ b/src/app/components/header/header.component.ts
@@ -1,0 +1,13 @@
+import { Component } from '@angular/core';
+import { RouterLink } from '@angular/router';
+
+@Component({
+  selector: 'app-header',
+  standalone: true,
+  imports: [RouterLink],
+  templateUrl: './header.component.html',
+  styleUrl: './header.component.css'
+})
+export class HeaderComponent {
+  title = 'Simple Dashboard';
+}

--- a/src/app/footer/footer.css
+++ b/src/app/footer/footer.css
@@ -1,0 +1,29 @@
+.app-footer {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+  background-color: rgba(0, 0, 0, 0.2);
+  color: white;
+  text-align: center;
+  gap: 8px;
+}
+
+.app-footer p {
+  margin: 0;
+  font-size: 0.9rem;
+  opacity: 0.9;
+}
+
+.app-footer a {
+  color: white;
+  text-decoration: underline;
+  font-size: 0.9rem;
+  opacity: 0.8;
+  transition: opacity 0.2s ease;
+}
+
+.app-footer a:hover {
+  opacity: 1;
+}

--- a/src/app/footer/footer.html
+++ b/src/app/footer/footer.html
@@ -1,0 +1,4 @@
+<footer class="app-footer">
+  <p>&copy; {{ currentYear }} {{ appName }}</p>
+  <a [href]="githubUrl" target="_blank" rel="noopener noreferrer">GitHub Repository</a>
+</footer>

--- a/src/app/footer/footer.spec.ts
+++ b/src/app/footer/footer.spec.ts
@@ -1,0 +1,45 @@
+import { TestBed } from '@angular/core/testing';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { FooterComponent } from './footer';
+
+describe('FooterComponent', () => {
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [FooterComponent]
+    }).compileComponents();
+  });
+
+  it('should create', () => {
+    const fixture = TestBed.createComponent(FooterComponent);
+    const component = fixture.componentInstance;
+    expect(component).toBeTruthy();
+  });
+
+  it('should display copyright year 2026', async () => {
+    const fixture = TestBed.createComponent(FooterComponent);
+    const component = fixture.componentInstance;
+    expect(component.currentYear).toBe(2026);
+    await fixture.whenStable();
+    const compiled = fixture.nativeElement as HTMLElement;
+    expect(compiled.textContent).toContain('2026');
+  });
+
+  it('should display app name Simple Dashboard', async () => {
+    const fixture = TestBed.createComponent(FooterComponent);
+    const component = fixture.componentInstance;
+    expect(component.appName).toBe('Simple Dashboard');
+    await fixture.whenStable();
+    const compiled = fixture.nativeElement as HTMLElement;
+    expect(compiled.textContent).toContain('Simple Dashboard');
+  });
+
+  it('should have a link to GitHub repository', async () => {
+    const fixture = TestBed.createComponent(FooterComponent);
+    await fixture.whenStable();
+    const compiled = fixture.nativeElement as HTMLElement;
+    const link = compiled.querySelector('a');
+    expect(link).toBeTruthy();
+    expect(link?.href).toBe('https://github.com/vinay4appsentinels/simple-dashboard');
+    expect(link?.target).toBe('_blank');
+  });
+});

--- a/src/app/footer/footer.ts
+++ b/src/app/footer/footer.ts
@@ -1,0 +1,13 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-footer',
+  standalone: true,
+  templateUrl: './footer.html',
+  styleUrl: './footer.css'
+})
+export class FooterComponent {
+  currentYear = 2026;
+  appName = 'Simple Dashboard';
+  githubUrl = 'https://github.com/vinay4appsentinels/simple-dashboard';
+}


### PR DESCRIPTION
## Summary
- Add comprehensive `docs/SNAPSHOT_GUIDE.md` documentation for capturing application screenshots
- Document headless browser automation process using Playwright
- Include troubleshooting section and automated snapshot script
- Update README.md with link to new documentation

## Changes
This PR adds a new documentation guide that covers:
- Prerequisites for taking snapshots
- Step-by-step instructions for cloning, building, and running the application
- Playwright-based headless screenshot capture
- S3 upload commands for artifact storage
- Troubleshooting common issues
- Automated snapshot script for convenience

## Test plan
- [x] Application builds successfully with `npm run build`
- [x] Documentation links correctly from README.md
- [x] All code examples are syntactically correct

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)