### PR TITLE
docs: Set main as default branch and remove unnecessary branches

### DIFF
--- a/docs/BRANCH_CLEANUP.md
+++ b/docs/BRANCH_CLEANUP.md
@@ -1,0 +1,40 @@
+# Branch Cleanup Summary
+
+This document records the repository cleanup performed to ensure proper branch management.
+
+## Date
+2026-01-01
+
+## Changes Made
+
+### 1. Default Branch Configuration
+- **Previous default branch:** `feature/task-1`
+- **New default branch:** `main`
+- The default branch was updated using: `gh repo edit vinay4appsentinels/simple-dashboard --default-branch main`
+
+### 2. Deleted Branches
+
+The following branches were deleted as they were either merged or no longer needed:
+
+| Branch | Reason for Deletion |
+|--------|---------------------|
+| `feature/task-1` | Old default branch, PR #2 merged, stale and diverged from main |
+| `feature/task-5` | PR #6 merged into main |
+| `feature/task-7` | PR #8 merged into main |
+| `feature/task-9` | PR #11 merged into main |
+| `feature/task-12` | PR #13 closed (not merged), associated issue #12 marked as done |
+
+### 3. Verification
+- Confirmed no open PRs were affected
+- Verified only `main` branch remains
+- Default branch is now correctly set to `main`
+
+## Branch Deletion Safety Checks
+Before deleting each branch, the following was verified:
+- No open pull requests using the branch
+- Branch was either merged into main or had associated closed/completed issues
+- No active development work on the branch
+
+## Remaining Branches
+After cleanup, only the following branch remains:
+- `main` (default branch)


### PR DESCRIPTION
## Summary
- Set `main` as the default branch (was previously `feature/task-1`)
- Deleted 5 stale/merged branches that were no longer needed
- Added documentation of the branch cleanup performed

## Changes Made

### Default Branch
Changed default branch from `feature/task-1` to `main`

### Deleted Branches
| Branch | Reason |
|--------|--------|
| `feature/task-1` | Old default, PR #2 merged, stale |
| `feature/task-5` | PR #6 merged |
| `feature/task-7` | PR #8 merged |
| `feature/task-9` | PR #11 merged |
| `feature/task-12` | PR #13 closed, issue #12 done |

### Remaining Branches
Only `main` remains after cleanup.

## Verification
- ✅ Confirmed no open PRs were affected
- ✅ Verified default branch is now `main`
- ✅ Only `main` branch remains

## Test plan
- [x] Verify default branch is `main`: `gh api repos/vinay4appsentinels/simple-dashboard --jq '.default_branch'`
- [x] Verify only `main` branch remains: `git branch -r`

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)