### PR TITLE
feat: Add current date display to welcome card

### DIFF
--- a/src/app/app.css
+++ b/src/app/app.css
@@ -28,3 +28,9 @@ p {
   font-size: 1.5rem;
   opacity: 0.9;
 }
+
+.current-date {
+  font-size: 1.2rem;
+  opacity: 0.8;
+  margin-top: 0.5rem;
+}

--- a/src/app/app.html
+++ b/src/app/app.html
@@ -3,6 +3,7 @@
 <main class="hello-world-container">
   <h1>Hello World!</h1>
   <p>Welcome to Simple Dashboard</p>
+  <p class="current-date">{{ currentDate }}</p>
 </main>
 
 <router-outlet />

--- a/src/app/app.spec.ts
+++ b/src/app/app.spec.ts
@@ -1,4 +1,5 @@
 import { TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
 import { describe, it, expect, beforeEach } from 'vitest';
 import { App } from './app';
 
@@ -6,6 +7,7 @@ describe('App', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [App],
+      providers: [provideRouter([])]
     }).compileComponents();
   });
 
@@ -17,14 +19,32 @@ describe('App', () => {
 
   it('should render Hello World title', async () => {
     const fixture = TestBed.createComponent(App);
+    fixture.detectChanges();
     await fixture.whenStable();
     const compiled = fixture.nativeElement as HTMLElement;
-    expect(compiled.querySelector('h1')?.textContent).toContain('Hello World!');
+    expect(compiled.querySelector('main h1')?.textContent).toContain('Hello World!');
   });
 
   it('should have the correct title property', () => {
     const fixture = TestBed.createComponent(App);
     const app = fixture.componentInstance;
     expect(app.title).toEqual('Simple Dashboard');
+  });
+
+  it('should return currentDate in correct format', () => {
+    const fixture = TestBed.createComponent(App);
+    const app = fixture.componentInstance;
+    const currentDate = app.currentDate;
+    expect(currentDate).toMatch(/^Today is \w+ \d{1,2}, \d{4}$/);
+  });
+
+  it('should display the current date in the template', async () => {
+    const fixture = TestBed.createComponent(App);
+    fixture.detectChanges();
+    await fixture.whenStable();
+    const compiled = fixture.nativeElement as HTMLElement;
+    const dateElement = compiled.querySelector('.current-date');
+    expect(dateElement).toBeTruthy();
+    expect(dateElement?.textContent).toMatch(/^Today is \w+ \d{1,2}, \d{4}$/);
   });
 });

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -11,4 +11,15 @@ import { HeaderComponent } from './components/header/header.component';
 })
 export class App {
   title = 'Simple Dashboard';
+
+  get currentDate(): string {
+    const now = new Date();
+    const options: Intl.DateTimeFormatOptions = {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric'
+    };
+    const formattedDate = now.toLocaleDateString('en-US', options);
+    return `Today is ${formattedDate}`;
+  }
 }


### PR DESCRIPTION
## Summary
- Added `currentDate` getter to the App component that formats the current date as 'Today is January 2, 2026'
- Updated the welcome card template to display the date below the welcome message
- Added matching CSS styling for the date element
- Fixed test configuration and added unit tests for the new functionality

Closes #16

## Test plan
- [x] Verify the current date is displayed in the correct format 'Today is [Month] [Day], [Year]'
- [x] Verify the date styling matches the existing card design
- [x] All existing tests pass
- [x] New unit tests verify the date format and template display
- [x] Build completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)